### PR TITLE
Fixed Resizing in play state

### DIFF
--- a/src/Grid.tsx
+++ b/src/Grid.tsx
@@ -29,9 +29,32 @@ class Grid extends React.Component<ComponentsProps, ComponentsState> {
 
 			this.setState({
 				size: {h, w},
-				gridState: this.generateEmptyState(h, w)
+				gridState: this.adjustGridToNewSize(this.state.gridState, h, w)
 			});
 		}
+	}
+
+	adjustGridToNewSize(grid: GridObject, newHeight: number, newWidth: number): GridObject {
+		const oldHeight = grid.length, oldWidth = grid[0].length;
+
+		for (let rowIndex = 0; rowIndex < oldHeight; rowIndex ++) {
+			grid[rowIndex] = this.truncateOrFillWith(newWidth, oldWidth, grid[rowIndex], 0);
+		}
+
+		grid = this.truncateOrFillWith(newHeight, oldHeight, grid ,this.generateEmptyColumn(newWidth));
+
+		return grid;
+	}
+
+	truncateOrFillWith<T>(newLength: number, oldLength: number, parent: T[], fillElement: T): T[] {
+		if (newLength < oldLength) {
+			parent = parent.splice(0, newLength);
+		} else {
+			for (let i = oldLength; i < newLength; i++) {
+				parent.push(fillElement)
+			}
+		}
+		return parent
 	}
 
 	componentDidMount(): void {
@@ -122,12 +145,17 @@ class Grid extends React.Component<ComponentsProps, ComponentsState> {
 	generateEmptyState(rowCount: number = this.state.size.h, columnCount: number = this.state.size.w ): GridObject {
 		let newState: GridObject = [];
 		for (let rowIndex = 0; rowIndex < rowCount; rowIndex ++) {
-			newState[rowIndex] = [];
-			for (let columnIndex = 0; columnIndex < columnCount; columnIndex ++) {
-				newState[rowIndex].push( 0 );
-			}
+			newState[rowIndex] = this.generateEmptyColumn(columnCount);
 		}
 		return newState;
+	}
+
+	generateEmptyColumn(columnSize: number): Alive[] {
+		let emptyColumn: Alive[] = [];
+		for (let columnIndex = 0; columnIndex < columnSize; columnIndex ++) {
+			emptyColumn.push( 0 );
+		}
+		return emptyColumn;
 	}
 
 	handleCellClick(e: React.SyntheticEvent, row: number, column: number) {
@@ -143,7 +171,7 @@ class Grid extends React.Component<ComponentsProps, ComponentsState> {
 
 	render () {
 		return (
-			<div className="bg-darkgreen flex-grow">
+			<div className="bg-darkgreen flex-grow flex-shrink overflow-hidden">
 				<div className="h-full p-2">
 					<div id="GridWrapper" className={"h-full flex justify-center content-center"}>
 						<GridLayout

--- a/src/NavBar.tsx
+++ b/src/NavBar.tsx
@@ -31,7 +31,7 @@ class NavBar extends React.Component<ComponentsProps, ComponentsState> {
 	render () {
 		const controlClassname = "h-full ml-8 inline-block cursor-pointer text-white ";
 		return (
-			<div className="w-full h-12 px-6 flex flex-wrap items-center justify-between bg-black">
+			<div className="w-full h-12 flex-shrink-0 px-6 flex flex-wrap items-center justify-between bg-black">
 				<div>
 					<span className="text-white font-extrabold text-3xl">Game of Life</span>
 				</div>


### PR DESCRIPTION
# Fixed Resizing in play state
## Issue description
The onResize event listener currently generates a new and empty grid with the updated width and height. When randomize the grid, run the simulation and then resize the window, the whole grid is cleared which is not expected behaviour.

## Fix description
Added a `adjustGridToNewSize` function that either adds new rows / columns or pops rows / columns depending on if the new size is bigger or smaller than the old one.